### PR TITLE
Add meiosis templates, riot route and final form

### DIFF
--- a/templates/final-form.riot
+++ b/templates/final-form.riot
@@ -1,0 +1,52 @@
+<component>
+
+    <form>
+
+        <div>
+            <label for="name">Name</label>
+            <input type="text" id="name" name="name" />
+            <div class="error"></div>
+        </div>
+
+        <button type='reset'>Reset</button>
+        <button type="submit">Submit</button>
+    </form>
+
+    <script>
+
+        import withFinalForm from 'riot-final-form';
+
+        export default withFinalForm({
+            formElement() {
+                return this.$('form');
+            },
+            onSubmit(values) {
+                alert(`$api.post('/stuff', ${JSON.stringify(values)})`);
+            },
+            initialValues: {
+                name: ''
+            },
+            validate(values) {
+                const errors = {};
+
+                if (!values.name) errors.name = 'name is required';
+
+                return errors;
+            },
+            onFormChange({ valid }) {
+                const submit = this.formElement().querySelector('[type=submit]');
+                submit.disabled = !valid;
+            },
+            onFieldChange(field, { touched, error }) {
+                const errorEl = field.parentElement.querySelector('.error');
+                if (touched && error) {
+                    if (errorEl) errorEl.innerHTML = error;
+                    field.parentElement.classList.add('error');
+                } else {
+                    if (errorEl) errorEl.innerHTML = '';
+                    field.parentElement.classList.remove('error');
+                }
+            }
+        });
+    </script>
+</component>

--- a/templates/meiosis/actions.js
+++ b/templates/meiosis/actions.js
@@ -12,7 +12,7 @@ export const fetchData = async (filter) => {
 
     stream.push({ data: data.results });
 
-    setFetching(true);
+    setFetching(false);
 };
 
 export const fetchOne = async () => {

--- a/templates/meiosis/actions.js
+++ b/templates/meiosis/actions.js
@@ -1,0 +1,27 @@
+import { getStream } from 'riot-meiosis';
+
+const stream = getStream();
+
+export const setFetching = (isFetching) => stream.push({ isFetching })
+
+export const fetchData = async (filter) => {
+
+    setFetching(true);
+
+    const { data } = await api.post('/search', filter);
+
+    stream.push({ data: data.results });
+
+    setFetching(true);
+};
+
+export const fetchOne = async () => {
+
+    setFetching(true);
+
+    const { data } = await api.get('/item/1');
+
+    stream.push({ current: data });
+
+    setFetching(false);
+};

--- a/templates/meiosis/component.riot
+++ b/templates/meiosis/component.riot
@@ -1,0 +1,48 @@
+<component>
+
+  <script>
+
+    import { connect, getState } from 'riot-meiosis';
+    import myActions from './actions';
+
+    // Optional mapping to component
+    const mapToComponent = myActions;
+    // OR
+    const mapToComponent = (ownProps, ownState) => myActions;
+
+
+    const mapToState = (appState, ownState, ownProps) => ({
+      ...ownState,
+      isFetching: appState.isFetching
+    });
+
+    const component = {
+      // state: {},
+      // onBeforeMount(props, state) {
+      // before the component is mounted
+      // },
+      // onMounted(props, state) {
+      // right after the component is mounted on the page
+      // },
+      // onBeforeUpdate(props, state) {
+      // allows recalculation of context data before the update
+      // },
+      // onUpdated(props, state) {
+      // right after the co mponent template is updated after an update call
+      // },
+      // onBeforeUnmount(props, state) {
+      // before the component is removed
+      // },
+      // onUnmounted(props, state) {
+      // when the component is removed from the page
+      // }
+    };
+
+
+    export default connect(mapToState)(component);
+    // OR
+    export default connect(mapToState, mapToComponent)(component);
+  </script>
+
+  <style></style>
+</component>

--- a/templates/meiosis/store.js
+++ b/templates/meiosis/store.js
@@ -1,0 +1,14 @@
+import { createStream } from 'riot-meiosis';
+
+const initialState = {
+    isFetching: false,
+    data: [],
+    error: null
+};
+
+const reducer = (newState, oldState) => ({
+    ...oldState,
+    ...newState
+});
+
+createStream(reducer, initialState);

--- a/templates/router.riot
+++ b/templates/router.riot
@@ -1,0 +1,14 @@
+<component>
+    <router>
+        <route path="/auth/login"><login /></route>
+        <route path="/user/:id/(.*)?"><edit-user /></route>
+    </route>
+
+    <script>
+        import { Router, Route } from '@riotjs/route'
+
+        export default {
+            components: { Router, Route }
+        };
+    </script>
+</component>


### PR DESCRIPTION
I don't think what I'm posting here is set up to work correctly, but I added some possible templates nested in `meiosis`. 

I am not entirely sure what the intended behavior is of the lib, but my knee jerk reaction was something like `npx tori componentIwant path/where/to/install` or maybe `npx tori new meiosis/actions ./components/users` which is why I nested things in a folder structure.

Attempts to solve https://github.com/graundsco/tori/issues/2